### PR TITLE
Add travis yaml and the kitchen yaml for travis tests

### DIFF
--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -1,0 +1,60 @@
+---
+driver:
+  name: proxy
+  host: localhost
+  reset_command: "exit 0"
+  port: <%= ENV["machine_port"] %>
+  username: <%= ENV["machine_user"] %>
+  password: <%= ENV["machine_pass"] %>
+
+provisioner:
+  name: chef_zero
+  product_name: chef
+  product_version: "14"
+  require_chef_omnibus: "14"
+  data_bags_path: "test/data_bags"
+  log_level: info
+
+platforms:
+  - name: ubuntu-14.04
+  - name: ubuntu-18.04
+  - name: ubuntu-16.04
+  - name: centos-7
+  - name: debian-9
+
+verifier:
+  name: inspec
+
+suites:
+  - name: Python3and2_pip19
+    driver_config:
+      vm_hostname: test-node1
+      customize:
+        memory: 512
+        cpus: 1
+    run_list:
+      - recipe[poise-python]
+    verifier:
+      inspec_tests:
+        - test/integration/base_python_tests
+    attributes:
+      poise-python:
+        install_python3: true
+        options:
+          pip_version: 19
+  - name: Python3and2_pip18
+    driver_config:
+      vm_hostname: test-node1
+      customize:
+         memory: 512
+         cpus: 1
+    run_list:
+      - recipe[poise-python]
+    verifier:
+      inspec_tests:
+        - test/integration/base_python_tests
+    attributes:
+      poise-python:
+        install_python3: true
+        options:
+          pip_version: 18

--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -1,11 +1,9 @@
 ---
 driver:
-  name: proxy
-  host: localhost
+  name: docker
+  use_sudo: false
+  privileged: true
   reset_command: "exit 0"
-  port: <%= ENV["machine_port"] %>
-  username: <%= ENV["machine_user"] %>
-  password: <%= ENV["machine_pass"] %>
 
 provisioner:
   name: chef_zero
@@ -16,22 +14,13 @@ provisioner:
   log_level: info
 
 platforms:
-  - name: ubuntu-14.04
-  - name: ubuntu-18.04
-  - name: ubuntu-16.04
-  - name: centos-7
-  - name: debian-9
+  - name: <%= ENV["platform"] %>
 
 verifier:
   name: inspec
 
 suites:
   - name: Python3and2_pip19
-    driver_config:
-      vm_hostname: test-node1
-      customize:
-        memory: 512
-        cpus: 1
     run_list:
       - recipe[poise-python]
     verifier:
@@ -43,11 +32,6 @@ suites:
         options:
           pip_version: 19
   - name: Python3and2_pip18
-    driver_config:
-      vm_hostname: test-node1
-      customize:
-         memory: 512
-         cpus: 1
     run_list:
       - recipe[poise-python]
     verifier:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# Use Travis's cointainer based infrastructure
+sudo: false
+addons:
+  apt:
+    sources:
+      - chef-stable-precise
+    packages:
+      - chefdk
+
+env:
+  global:
+    - machine_user=travis
+    - machine_pass=travis
+    - machine_port=22
+    - KITCHEN_YAML=.kitchen.travis.yml
+
+# Don't `bundle install`
+install: echo "skip bundle install"
+
+branches:
+  only:
+    - master
+
+# Ensure we make ChefDK's Ruby the default
+before_script:
+  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+
+script:
+  - /opt/chefdk/embedded/bin/cookstyle .
+  - /opt/chefdk/embedded/bin/foodcritic .
+  - /opt/chefdk/bin/kitchen test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,22 @@
-# Use Travis's cointainer based infrastructure
 sudo: false
+
 addons:
   apt:
     sources:
       - chef-stable-precise
     packages:
       - chefdk
+      - docker-ce
 
 env:
   global:
-    - machine_user=travis
-    - machine_pass=travis
-    - machine_port=22
     - KITCHEN_YAML=.kitchen.travis.yml
+  matrix:
+    - platform=ubuntu-14.04
+    - platform=ubuntu-16.04
+    - platform=ubuntu-18.04
+    - platform=debian-8
+    - platform=centos-7
 
 # Don't `bundle install`
 install: echo "skip bundle install"
@@ -24,8 +28,9 @@ branches:
 # Ensure we make ChefDK's Ruby the default
 before_script:
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+  - /opt/chefdk/bin/chef gem install kitchen-docker
 
 script:
-  - /opt/chefdk/embedded/bin/cookstyle .
-  - /opt/chefdk/embedded/bin/foodcritic .
+  - /opt/chefdk/embedded/bin/cookstyle --version
+  - /opt/chefdk/embedded/bin/foodcritic --version
   - /opt/chefdk/bin/kitchen test

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Note!!!
 
-I am not the origional authur of this cookbook. 
-This is a patched fork for other users who still use it and need fixes
+Enova is not the origional authur of this cookbook. The poise-python cookbook has been archived.
+As a result, Enova has forked and patched this cookbook for users that still require fixes.
 
-It can be used by adding the following to your berks file
+It can be used by adding the following to your berks file:
 ```
 cookbook 'poise-python', git: 'https://github.com/enova/enova-python.git'
 ```
 
-if you need the install function youll need to lock to pip 18 currently in your attributes or recipe
+if you need the install function you'll need to lock to pip 18 currently in your attributes or recipe
 attribute line
 ```
 default['poise-python']['options']['pip_version'] = '18.0'
@@ -18,7 +18,8 @@ recipe file
 node.default['poise-python']['options']['pip_version'] = '18.0'
 include_recipe 'poise-python'
 ```
-# Poise-Python Cookbook
+
+# Poise-Python Cookbook [![Build Status](https://travis-ci.org/enova/enova-python.svg?branch=master)](https://travis-ci.org/enova/enova-python)
 A [Chef](https://www.chef.io/) cookbook to provide a unified interface for
 installing Python, managing Python packages, and creating virtualenvs.
 


### PR DESCRIPTION
Update the readme for basics.

Add Travis integration so that it will run docker kitchen for each platform setup in the travis.yml